### PR TITLE
Made search more efficient

### DIFF
--- a/colab/unsplash-image-search.ipynb
+++ b/colab/unsplash-image-search.ipynb
@@ -242,13 +242,13 @@
       "source": [
         "def find_best_matches(text_features, photo_features, photo_ids, results_count=3):\n",
         "  # Compute the similarity between the search query and each photo using the Cosine similarity\n",
-        "  similarities = list((text_features @ photo_features.T).squeeze(0))\n",
+        "  similarities = (photo_features @ text_features.T).squeeze(1)\n",
         "\n",
-        "  # Sort the photos by their similarity score and attach the photo ID to the score\n",
-        "  best_photos = sorted(zip(similarities, photo_ids), key=lambda x: x[0], reverse=True)\n",
+        "  # Sort the photos by their similarity score\n",
+        "  best_photo_idx = np.argsort(similarities)[::-1]\n",
         "\n",
         "  # Return the photo IDs of the best matches\n",
-        "  return [best_photos[i][1] for i in range(results_count)]"
+        "  return [photo_ids[i] for i in best_photo_idx[:results_count]]"
       ],
       "execution_count": 7,
       "outputs": []


### PR DESCRIPTION
There were 2 sources of inefficiency in the `find_best_matches` function:
- Transposing the (large) image feature array
- Sorting the results

This change addresses those, and in a Colab notebook the execution of that function went down from ~20s before the change to ~3s after the change.