### PR TITLE
Optimize unsplash proxy

### DIFF
--- a/unsplash-proxy/handler.py
+++ b/unsplash-proxy/handler.py
@@ -3,8 +3,14 @@ import logging
 from urllib.request import urlopen
 
 
+# Setup the logger
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
+
+
+# Get the Unsplash Access Key from the Parameter Store
+client = boto3.client("ssm")
+access_key = client.get_parameter(Name="UNSPLAH_API_ACCESS_KEY")["Parameter"]["Value"]
 
 
 def get_photo(event, context):
@@ -12,12 +18,6 @@ def get_photo(event, context):
 
     # Get the photo ID from the parameters
     photo_id = event["pathParameters"]["id"]
-
-    # Get the Unsplash Access Key from the Parameter Store
-    client = boto3.client("ssm")
-    access_key = client.get_parameter(Name="UNSPLAH_API_ACCESS_KEY")["Parameter"][
-        "Value"
-    ]
 
     # Call the Unsplash API to get the photo metadata
     photo_data_url = (

--- a/unsplash-proxy/serverless.yml
+++ b/unsplash-proxy/serverless.yml
@@ -5,30 +5,30 @@ org: haltakov
 frameworkVersion: "2"
 
 provider:
-  name: aws
-  runtime: python3.8
-  iamRoleStatements:
-    - Effect: Allow
-      Action:
-        - ssm:GetParameter
-      Resource: "arn:aws:ssm:us-east-1:018469183656:parameter/UNSPLAH_API_ACCESS_KEY"
+    name: aws
+    runtime: python3.8
+    iamRoleStatements:
+        - Effect: Allow
+          Action:
+              - ssm:GetParameter
+          Resource: "arn:aws:ssm:us-east-1:018469183656:parameter/UNSPLAH_API_ACCESS_KEY"
 
 plugins:
-  - serverless-api-gateway-caching
+    - serverless-api-gateway-caching
 custom:
-  apiGatewayCaching:
-    enabled: true
+    apiGatewayCaching:
+        enabled: true
 
 functions:
-  get_photo:
-    handler: handler.get_photo
-    memorySize: 256
-    events:
-      - http:
-          path: get_photo/{id}
-          method: get
-          cors: true
-          caching:
-            enabled: true
-            cacheKeyParameters:
-              - name: request.path.id
+    get_photo:
+        handler: handler.get_photo
+        memorySize: 128
+        events:
+            - http:
+                  path: get_photo/{id}
+                  method: get
+                  cors: true
+                  caching:
+                      enabled: true
+                      cacheKeyParameters:
+                          - name: request.path.id


### PR DESCRIPTION
This PR optimized the unsplash-proxy to reduce costs and speed it up.

- Cache the fetching of the Unsplash API key from the parameter store
- Reduce the RAM of the function to 128 (more than enough)